### PR TITLE
feat: Configure Helm chart for ArgoCD Vault Plugin integration

### DIFF
--- a/helm/golang-app/templates/deployment.yaml
+++ b/helm/golang-app/templates/deployment.yaml
@@ -44,6 +44,10 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/helm/golang-app/values.yaml
+++ b/helm/golang-app/values.yaml
@@ -26,6 +26,7 @@ podAnnotations: {}
 
 # Environment variables for the golang application
 # Using ArgoCD Vault Plugin syntax to pull secrets from Vault
+# Note: ArgoCD must be configured with argocd-vault-plugin for these to work
 env:
   - name: DB_HOST
     value: <path:kv/data/database#host>
@@ -37,6 +38,9 @@ env:
     value: <path:kv/data/database#user>
   - name: DB_PASSWORD
     value: <path:kv/data/database#password>
+  - name: DB_SSL_MODE
+    value: "disable"
+
 # This is for setting Kubernetes Labels to a Pod.
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 podLabels: {}


### PR DESCRIPTION
- Replace Vault Agent injection with ArgoCD Vault Plugin approach
- Add environment variables section in values.yaml with Vault path syntax
- Configure deployment template to inject env vars from values.yaml
- Add database environment variables using <path:kv/data/database#field> syntax
- Include DB_SSL_MODE configuration for PostgreSQL connection
- Update replica count to 2 for better availability
- Remove complex Vault Agent annotations that were causing init container failures

This approach uses ArgoCD Vault Plugin to replace <path:...> placeholders with actual Vault secrets during deployment, eliminating the need for Vault Agent sidecar containers and Kubernetes auth configuration.

Requires ArgoCD to be configured with argocd-vault-plugin.