### PR TITLE
fix: update External Secrets API version from v1beta1 to v1

### DIFF
--- a/helm/golang-app/templates/external-secrets.yaml
+++ b/helm/golang-app/templates/external-secrets.yaml
@@ -1,5 +1,5 @@
 # SecretStore - connects to Vault
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: SecretStore
 metadata:
   name: vault-backend
@@ -21,7 +21,7 @@ spec:
 
 ---
 # ExternalSecret - fetches database secrets from Vault
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ include "..fullname" . }}-database-secrets


### PR DESCRIPTION
- Update SecretStore apiVersion to external-secrets.io/v1
- Update ExternalSecret apiVersion to external-secrets.io/v1
- Fixes compatibility with installed External Secrets Operator v1