### PR TITLE
feat: implement vault token bootstrap approach for ArgoCD

### DIFF
--- a/helm/golang-app/bootstrap-secret.yaml
+++ b/helm/golang-app/bootstrap-secret.yaml
@@ -1,0 +1,11 @@
+# This secret should be created manually in the cluster ONCE
+# kubectl create secret generic vault-bootstrap-token --from-literal=token="YOUR_VAULT_ROOT_TOKEN" -n default
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vault-bootstrap-token
+  namespace: default
+type: Opaque
+data:
+  # This will be created manually outside of git
+  # token: <base64-encoded-vault-token>

--- a/helm/golang-app/templates/external-secrets.yaml
+++ b/helm/golang-app/templates/external-secrets.yaml
@@ -13,11 +13,9 @@ spec:
       path: "kv"
       version: "v2"
       auth:
-        kubernetes:
-          mountPath: "kubernetes"
-          role: {{ .Values.vault.role | quote }}
-          serviceAccountRef:
-            name: {{ include "..serviceAccountName" . }}
+        tokenSecretRef:
+          name: "vault-bootstrap-token"  # Pre-created secret outside git
+          key: "token"
 
 ---
 # ExternalSecret - fetches database secrets from Vault

--- a/helm/golang-app/values.yaml
+++ b/helm/golang-app/values.yaml
@@ -33,6 +33,7 @@ vault:
   address: "http://a7f90ff1105d746a5a785087b130fc75-232304810.us-east-1.elb.amazonaws.com:8200"
   role: "golang-app"
   refreshInterval: "1h"
+  # Token is provided via pre-created 'vault-bootstrap-token' secret
 
 # This is for setting Kubernetes Labels to a Pod.
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/


### PR DESCRIPTION
- Use pre-created 'vault-bootstrap-token' secret for External Secrets authentication
- Update external-secrets.yaml to reference bootstrap token secret instead of Kubernetes auth
- Add bootstrap-secret.yaml documentation for manual secret creation
- Clean approach that works with ArgoCD without exposing secrets in git