### PR TITLE
feat: enable Ingress and HPA for golang application

### DIFF
--- a/helm/golang-app/values.yaml
+++ b/helm/golang-app/values.yaml
@@ -61,7 +61,7 @@ service:
 
 # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:
-  enabled: false
+  enabled: true # Enable ingress
   className: ""
   annotations:
     {}
@@ -97,7 +97,7 @@ readinessProbe:
 
 # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:
-  enabled: false
+  enabled: true # Enable HPA
   minReplicas: 1
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80


### PR DESCRIPTION
- Enable ingress to expose API at api.shipcodes.tech
- Enable Horizontal Pod Autoscaler with 1-100 replicas based on CPU usage
- Resources will now appear in ArgoCD for monitoring