### PR TITLE
feat: add NGINX Ingress Controller for custom domain support

### DIFF
--- a/helm/golang-app/values.yaml
+++ b/helm/golang-app/values.yaml
@@ -51,20 +51,20 @@ securityContext:
 # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:
   # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
-  type: LoadBalancer # Changed to LoadBalancer for external access
+  type: ClusterIP # Use ClusterIP since NGINX Ingress will handle external access
   # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
   port: 8080
 
 # This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:
   enabled: true
-  className: ""
+  className: "nginx" # Use NGINX Ingress Controller
   annotations: {}
   hosts:
     - host: api.shipcodes.tech
       paths:
         - path: /
-          pathType: ImplementationSpecific
+          pathType: Prefix # Change from ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/infrastructure/18-nginx-ingress.tf
+++ b/infrastructure/18-nginx-ingress.tf
@@ -1,0 +1,23 @@
+# NGINX Ingress Controller
+resource "helm_release" "nginx_ingress" {
+  name       = "ingress-nginx"
+  repository = "https://kubernetes.github.io/ingress-nginx"
+  chart      = "ingress-nginx"
+  namespace  = "ingress-nginx"
+  version    = "4.8.1"
+  create_namespace = true
+
+  set {
+    name  = "controller.service.type"
+    value = "LoadBalancer"
+  }
+
+  set {
+    name  = "controller.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-type"
+    value = "nlb"
+  }
+
+  depends_on = [
+    aws_eks_node_group.eks_node_group
+  ]
+}


### PR DESCRIPTION
- Add Terraform configuration for NGINX Ingress Controller with NLB
- Update Helm values to use nginx ingress class with api.shipcodes.tech
- Change service type to ClusterIP since NGINX handles external access
- Configure ingress with Prefix pathType for better routing
- Enables clean domain access instead of raw LoadBalancer URLs